### PR TITLE
feat: validated writable + readonly accounts of a transaction

### DIFF
--- a/lockbox/src/lock/mod.rs
+++ b/lockbox/src/lock/mod.rs
@@ -30,13 +30,10 @@ pub enum AccountLockState {
     /// The account was found on chain and is not locked and therefore should
     /// not be used as writable on the ephemeral validator
     Unlocked,
-    // TODO(thlorenz): what about state diff and commit record
-    // - are they expected at the PDA addresses?
-    // - are they optional?
-    // - should we indicate if they were found?
-    // - if so what predicates do they need to match?
     /// The account was found on chain in a proper locked state which means we
     /// also found the related accounts like the buffer and delegation
+    /// NOTE: commit records and state diff accountsk are not checked since an
+    /// account is delegated and then used before the validator commits a state change.
     Locked {
         delegated_id: Pubkey,
         delegation_pda: Pubkey,

--- a/transwise/src/errors.rs
+++ b/transwise/src/errors.rs
@@ -1,3 +1,4 @@
+use solana_sdk::pubkey::Pubkey;
 use thiserror::Error;
 
 pub type TranswiseResult<T> = std::result::Result<T, TranswiseError>;
@@ -6,4 +7,16 @@ pub type TranswiseResult<T> = std::result::Result<T, TranswiseError>;
 pub enum TranswiseError {
     #[error("LockboxError")]
     LockboxError(#[from] conjunto_lockbox::errors::LockboxError),
+
+    #[error("Not all writable accounts are locked")]
+    NotAllWritablesLocked {
+        locked: Vec<Pubkey>,
+        unlocked: Vec<Pubkey>,
+    },
+
+    #[error("Writables inconsistent accounts")]
+    WritablesIncludeInconsistentAccounts { inconsistent: Vec<Pubkey> },
+
+    #[error("Writables include new accounts")]
+    WritablesIncludeNewAccounts { new_accounts: Vec<Pubkey> },
 }

--- a/transwise/src/lib.rs
+++ b/transwise/src/lib.rs
@@ -1,5 +1,6 @@
 mod api;
 pub mod errors;
 pub mod trans_account_meta;
+pub mod validated_accounts;
 
 pub use api::Transwise;

--- a/transwise/src/trans_account_meta.rs
+++ b/transwise/src/trans_account_meta.rs
@@ -271,28 +271,43 @@ impl TransAccountMetas {
         }
     }
 
-    fn locked_writables(&self) -> Vec<&TransAccountMeta> {
+    pub(crate) fn writable_pubkeys(&self) -> Vec<Pubkey> {
+        self.locked_writables()
+            .iter()
+            .chain(self.new_writables().iter())
+            .map(|x| *x.pubkey())
+            .collect()
+    }
+
+    pub(crate) fn readable_pubkeys(&self) -> Vec<Pubkey> {
+        self.iter()
+            .filter(|x| matches!(x, TransAccountMeta::Readonly { .. }))
+            .map(|x| *x.pubkey())
+            .collect()
+    }
+
+    pub(crate) fn locked_writables(&self) -> Vec<&TransAccountMeta> {
         self
             .iter()
             .filter(|x| matches!(x, TransAccountMeta::Writable { lockstate, .. } if lockstate.is_locked()))
             .collect()
     }
 
-    fn unlocked_writables(&self) -> Vec<&TransAccountMeta> {
+    pub(crate) fn unlocked_writables(&self) -> Vec<&TransAccountMeta> {
         self
             .iter()
             .filter(|x| matches!(x, TransAccountMeta::Writable { lockstate, .. } if lockstate.is_unlocked()))
             .collect()
     }
 
-    fn new_writables(&self) -> Vec<&TransAccountMeta> {
+    pub(crate) fn new_writables(&self) -> Vec<&TransAccountMeta> {
         self
             .iter()
             .filter(|x| matches!(x, TransAccountMeta::Writable { lockstate, .. } if lockstate.is_new()))
             .collect()
     }
 
-    fn inconsistent_writables(&self) -> Vec<&TransAccountMeta> {
+    pub(crate) fn inconsistent_writables(&self) -> Vec<&TransAccountMeta> {
         self
             .iter()
             .filter(|x| matches!(x, TransAccountMeta::Writable { lockstate, .. } if lockstate.is_inconsistent()))

--- a/transwise/src/validated_accounts.rs
+++ b/transwise/src/validated_accounts.rs
@@ -1,0 +1,201 @@
+use solana_sdk::pubkey::Pubkey;
+
+use crate::{errors::TranswiseError, trans_account_meta::TransAccountMetas};
+
+#[derive(Debug, Default)]
+pub struct ValidateAccountsConfig {
+    pub allow_new_accounts: bool,
+}
+
+pub struct ValidatedAccounts {
+    pub readonly: Vec<Pubkey>,
+    pub writable: Vec<Pubkey>,
+}
+
+impl TryFrom<(&TransAccountMetas, &ValidateAccountsConfig)>
+    for ValidatedAccounts
+{
+    type Error = TranswiseError;
+
+    fn try_from(
+        (meta, config): (&TransAccountMetas, &ValidateAccountsConfig),
+    ) -> Result<Self, Self::Error> {
+        let unlocked = meta.unlocked_writables();
+        if !unlocked.is_empty() {
+            return Err(TranswiseError::NotAllWritablesLocked {
+                locked: meta
+                    .locked_writables()
+                    .into_iter()
+                    .map(|x| *x.pubkey())
+                    .collect(),
+                unlocked: meta
+                    .unlocked_writables()
+                    .into_iter()
+                    .map(|x| *x.pubkey())
+                    .collect(),
+            });
+        }
+
+        let inconsistent = meta.inconsistent_writables();
+        if !inconsistent.is_empty() {
+            return Err(TranswiseError::WritablesIncludeInconsistentAccounts {
+                inconsistent: meta
+                    .inconsistent_writables()
+                    .into_iter()
+                    .map(|x| *x.pubkey())
+                    .collect(),
+            });
+        }
+
+        if !config.allow_new_accounts && !meta.new_writables().is_empty() {
+            return Err(TranswiseError::WritablesIncludeNewAccounts {
+                new_accounts: meta
+                    .new_writables()
+                    .into_iter()
+                    .map(|x| *x.pubkey())
+                    .collect(),
+            });
+        }
+        Ok(ValidatedAccounts {
+            readonly: meta.readable_pubkeys(),
+            writable: meta.writable_pubkeys(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use conjunto_lockbox::AccountLockState;
+
+    use crate::{
+        errors::TranswiseResult, trans_account_meta::TransAccountMeta,
+    };
+
+    use super::*;
+
+    fn config_no_new_accounts() -> ValidateAccountsConfig {
+        ValidateAccountsConfig {
+            allow_new_accounts: false,
+        }
+    }
+
+    fn config_allow_new_accounts() -> ValidateAccountsConfig {
+        ValidateAccountsConfig {
+            allow_new_accounts: true,
+        }
+    }
+
+    fn locked() -> AccountLockState {
+        AccountLockState::Locked {
+            delegated_id: Pubkey::new_unique(),
+            delegation_pda: Pubkey::new_unique(),
+        }
+    }
+
+    fn unlocked() -> AccountLockState {
+        AccountLockState::Unlocked
+    }
+
+    fn new_account() -> AccountLockState {
+        AccountLockState::NewAccount
+    }
+
+    fn inconsistent() -> AccountLockState {
+        AccountLockState::Inconsistent {
+            delegated_id: Pubkey::new_unique(),
+            delegation_pda: Pubkey::new_unique(),
+            inconsistencies: vec![],
+        }
+    }
+
+    #[test]
+    fn test_locked_writable_two_readonly() {
+        let readonly_id1 = Pubkey::new_unique();
+        let readonly_id2 = Pubkey::new_unique();
+        let writable_id = Pubkey::new_unique();
+
+        let meta1 = TransAccountMeta::readonly(readonly_id1);
+        let meta2 = TransAccountMeta::readonly(readonly_id2);
+        let meta3 = TransAccountMeta::Writable {
+            pubkey: writable_id,
+            lockstate: locked(),
+        };
+
+        let vas: ValidatedAccounts = (
+            &TransAccountMetas(vec![meta1, meta2, meta3]),
+            &config_no_new_accounts(),
+        )
+            .try_into()
+            .unwrap();
+
+        assert_eq!(vas.readonly, vec![readonly_id1, readonly_id2]);
+        assert_eq!(vas.writable, vec![writable_id]);
+    }
+
+    #[test]
+    fn test_unlocked_writable_one_readonly() {
+        let readonly_id = Pubkey::new_unique();
+        let writable_id = Pubkey::new_unique();
+
+        let meta1 = TransAccountMeta::readonly(readonly_id);
+        let meta2 = TransAccountMeta::Writable {
+            pubkey: writable_id,
+            lockstate: unlocked(),
+        };
+
+        let res: TranswiseResult<ValidatedAccounts> = (
+            &TransAccountMetas(vec![meta1, meta2]),
+            &config_no_new_accounts(),
+        )
+            .try_into();
+
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_inconsistent_writable_one_readonly() {
+        let readonly_id = Pubkey::new_unique();
+        let writable_id = Pubkey::new_unique();
+
+        let meta1 = TransAccountMeta::readonly(readonly_id);
+        let meta2 = TransAccountMeta::Writable {
+            pubkey: writable_id,
+            lockstate: inconsistent(),
+        };
+
+        let res: TranswiseResult<ValidatedAccounts> = (
+            &TransAccountMetas(vec![meta1, meta2]),
+            &config_no_new_accounts(),
+        )
+            .try_into();
+
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_locked_writable_one_new_writable_one_readonly_allowing_new() {
+        let readonly_id1 = Pubkey::new_unique();
+        let new_writable_id = Pubkey::new_unique();
+        let locked_writable_id = Pubkey::new_unique();
+
+        let meta1 = TransAccountMeta::readonly(readonly_id1);
+        let meta2 = TransAccountMeta::Writable {
+            pubkey: new_writable_id,
+            lockstate: new_account(),
+        };
+        let meta3 = TransAccountMeta::Writable {
+            pubkey: locked_writable_id,
+            lockstate: locked(),
+        };
+
+        let vas: ValidatedAccounts = (
+            &TransAccountMetas(vec![meta1, meta2, meta3]),
+            &config_allow_new_accounts(),
+        )
+            .try_into()
+            .unwrap();
+
+        assert_eq!(vas.readonly, vec![readonly_id1]);
+        assert_eq!(vas.writable, vec![locked_writable_id, new_writable_id]);
+    }
+}


### PR DESCRIPTION
## Summary

Adding two API methods that allow to get writable and readonly accounts found in a transaction.
Before they are returned the writables are checked to either be properly locked or new accounts
if the config allows that latter case.
