### PR TITLE
feat: marking new validated writable accounts

### DIFF
--- a/transwise/src/trans_account_meta.rs
+++ b/transwise/src/trans_account_meta.rs
@@ -16,6 +16,7 @@ use crate::{
 // -----------------
 // SanitizedTransactionAccountsHolder
 // -----------------
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TransactionAccountsHolder {
     pub writable: Vec<Pubkey>,
     pub readonly: Vec<Pubkey>,
@@ -441,6 +442,7 @@ impl TransAccountMetas {
                     pubkey: *x.pubkey(),
                     is_payer: x.is_payer(),
                     lock_config: Some(config.clone()),
+                    is_new: false,
                 }),
                 _ => None,
             })
@@ -458,6 +460,7 @@ impl TransAccountMetas {
                         pubkey: *x.pubkey(),
                         is_payer: x.is_payer(),
                         lock_config: None,
+                        is_new: false,
                     })
                 }
                 _ => None,
@@ -481,6 +484,7 @@ impl TransAccountMetas {
                         pubkey: *x.pubkey(),
                         is_payer: x.is_payer(),
                         lock_config: None,
+                        is_new: false,
                     })
                 }
                 _ => None,
@@ -498,6 +502,7 @@ impl TransAccountMetas {
                         pubkey: *x.pubkey(),
                         is_payer: x.is_payer(),
                         lock_config: None,
+                        is_new: true,
                     })
                 }
                 _ => None,

--- a/transwise/src/validated_accounts.rs
+++ b/transwise/src/validated_accounts.rs
@@ -35,6 +35,10 @@ pub struct ValidatedWritableAccount {
     /// Indicates if this account was a payer in the transaction from which
     /// it was extracted.
     pub is_payer: bool,
+
+    /// Indicates that this account was not found on chain but was included
+    /// since we allow new accounts to be created.
+    pub is_new: bool,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
New accounts are not found on chain and the validator needs to identify new accounts and not attempt to clone them.
Instead it will do nothing and have the transaction execution itself handle this case, i.e. the account might be created as part of it like in the case of an airdrop.

