### PR TITLE
fix: Fix delegation record parsing to include delegation_slot

### DIFF
--- a/core/src/delegation_record.rs
+++ b/core/src/delegation_record.rs
@@ -35,6 +35,8 @@ impl From<CommitFrequency> for Duration {
 pub struct DelegationRecord {
     /// The original owner of the account
     pub owner: Pubkey,
+    /// The slot at which the delegation was created
+    pub delegation_slot: u64,
     /// The frequency at which to commit the account state of the ephemeral
     /// validator to the chain.
     pub commit_frequency: CommitFrequency,
@@ -44,6 +46,7 @@ impl DelegationRecord {
     pub fn default_with_owner(owner: Pubkey) -> Self {
         Self {
             owner,
+            delegation_slot: 0,
             commit_frequency: CommitFrequency::Millis(1_000),
         }
     }

--- a/lockbox/src/delegation_record_parser_impl.rs
+++ b/lockbox/src/delegation_record_parser_impl.rs
@@ -33,6 +33,7 @@ fn parse_delegation_record(data: &[u8]) -> CoreResult<DelegationRecord> {
     let state = result.unwrap();
     Ok(DelegationRecord {
         owner: state.owner,
+        delegation_slot: state.delegation_slot,
         commit_frequency: CommitFrequency::Millis(state.commit_frequency_ms),
     })
 }

--- a/lockbox/tests/account_chain_snapshot.rs
+++ b/lockbox/tests/account_chain_snapshot.rs
@@ -23,6 +23,7 @@ fn default_delegation_record() -> DelegationRecord {
     DelegationRecord {
         commit_frequency: CommitFrequency::Millis(1_000),
         owner: Pubkey::new_unique(),
+        delegation_slot: 0,
     }
 }
 

--- a/lockbox/tests/account_chain_state_devnet.rs
+++ b/lockbox/tests/account_chain_state_devnet.rs
@@ -19,6 +19,7 @@ fn default_delegation_record() -> DelegationRecord {
     DelegationRecord {
         commit_frequency: CommitFrequency::Millis(1_000),
         owner: Pubkey::new_unique(),
+        delegation_slot: 0,
     }
 }
 

--- a/lockbox/tests/delegation_record_parser.rs
+++ b/lockbox/tests/delegation_record_parser.rs
@@ -8,12 +8,12 @@ use solana_sdk::pubkey::Pubkey;
 #[test]
 fn test_delegation_record_parser() {
     // NOTE: from delegation-program/tests/fixtures/accounts.rs
-    let delegation_record_account_data: [u8; 80] = [
+    let delegation_record_account_data: [u8; 88] = [
         100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 43, 85, 175, 207,
         195, 148, 154, 129, 218, 62, 110, 177, 81, 112, 72, 172, 141, 157, 3,
-        211, 24, 26, 191, 79, 101, 191, 48, 19, 105, 181, 70, 132, 48, 117, 0,
-        0, 0, 0, 0, 0,
+        211, 24, 26, 191, 79, 101, 191, 48, 19, 105, 181, 70, 132, 4, 0, 0, 0,
+        0, 0, 0, 0, 48, 117, 0, 0, 0, 0, 0, 0,
     ];
     let parser = DelegationRecordParserImpl;
     let record = parser.try_parse(&delegation_record_account_data).unwrap();
@@ -24,6 +24,7 @@ fn test_delegation_record_parser() {
                 "3vAK9JQiDsKoQNwmcfeEng4Cnv22pYuj1ASfso7U4ukF"
             )
             .unwrap(),
+            delegation_slot: 4,
             commit_frequency: CommitFrequency::Millis(30_000),
         }
     );

--- a/transwise/tests/transaction_accounts_validator.rs
+++ b/transwise/tests/transaction_accounts_validator.rs
@@ -28,6 +28,7 @@ fn chain_snapshot_delegated() -> AccountChainSnapshotShared {
             delegation_record: DelegationRecord {
                 commit_frequency: CommitFrequency::Millis(1_000),
                 owner: Pubkey::new_unique(),
+                delegation_slot: 0,
             },
         },
     }


### PR DESCRIPTION
## Description

Fix the delegation record parsing to include include `delegation_slot`, after the refactoring done in https://github.com/magicblock-labs/delegation-program/pull/33