### PR TITLE
bug: validator crash when delegation record parsing fails

### DIFF
--- a/lockbox/src/delegation_record_parser_impl.rs
+++ b/lockbox/src/delegation_record_parser_impl.rs
@@ -20,17 +20,15 @@ fn parse_delegation_record(data: &[u8]) -> CoreResult<DelegationRecord> {
     // NOTE: I didn't find 100% confirmation that vecs are always correctly aligned, but
     // the issue I encountered was fixed by this change.
     // TODO(thlorenz): with this fix we copy data and should revisit this to avoid that
-    let data = data.to_vec();
-    let result =
-        bytemuck::try_from_bytes::<dlp::state::DelegationRecord>(&data[8..])
+    let aligned_data = data[8..].to_vec();
+    let state =
+        bytemuck::try_from_bytes::<dlp::state::DelegationRecord>(&aligned_data)
             .map_err(|err| {
                 CoreError::FailedToParseDelegationRecord(format!(
                     "Failed to deserialize DelegationRecord: {}",
                     err
                 ))
-            });
-
-    let state = result.unwrap();
+            })?;
     Ok(DelegationRecord {
         owner: state.owner,
         delegation_slot: state.delegation_slot,


### PR DESCRIPTION
## Summary

Due to a simple `unwrap`, the validator was completely crashing instead of continuing operation when a delegation record failure happened