### PR TITLE
chore: expose lockbox error types in transwise

### DIFF
--- a/transwise/src/lib.rs
+++ b/transwise/src/lib.rs
@@ -14,6 +14,8 @@ pub use conjunto_lockbox::account_chain_snapshot_provider::AccountChainSnapshotP
 pub use conjunto_lockbox::account_chain_snapshot_shared::AccountChainSnapshotShared;
 pub use conjunto_lockbox::account_chain_state::AccountChainState;
 pub use conjunto_lockbox::delegation_record_parser_impl::DelegationRecordParserImpl;
+pub use conjunto_lockbox::errors::LockboxError;
+pub use conjunto_lockbox::errors::LockboxResult;
 pub use conjunto_providers::rpc_account_provider::RpcAccountProvider;
 pub use conjunto_providers::rpc_provider_config::RpcProviderConfig;
 pub use conjunto_providers::RpcCluster;


### PR DESCRIPTION
## Summary

Those two types `LockboxError`/`LockboxResult` are not exposed as part of the transwise API, but are exposed through the `AccountChainSnapshotProvider` type